### PR TITLE
Send full callId i ProblemDetails

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/soknad/server/error/ProblemDetails.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/server/error/ProblemDetails.java
@@ -5,6 +5,6 @@ import no.nav.vedtak.log.mdc.MDCOperations;
 public record ProblemDetails(FeilKode feilKode, int status, String message, String callId) {
 
     public ProblemDetails(FeilKode feilKode, int status, String message) {
-        this(feilKode, status, message, MDCOperations.getCallId().substring(0, 5));
+        this(feilKode, status, message, MDCOperations.getCallId());
     }
 }


### PR DESCRIPTION
Fjern substring(0, 5) slik at full callId sendes til frontend. Frontend truncerer for brukervisning, men logger full callId til Sentry.