### PR TITLE
TFP-6956: avvis overlappende uttaksperioder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <prosesstask.version>5.2.5</prosesstask.version>
         <fp-kontrakter.version>9.4.31</fp-kontrakter.version>
         <soknad-kontrakt.version>1.0.4</soknad-kontrakt.version>
+        <fpsak-tidsserie.version>2.7.4</fpsak-tidsserie.version>
 
         <openapi-spec-utils.version>2.1.0</openapi-spec-utils.version>
         <tika.version>3.2.3</tika.version> <!-- Bedre måter å gjøre det på -->
@@ -59,6 +60,11 @@
                 <version>${fp-kontrakter.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.fpsak.tidsserie</groupId>
+                <artifactId>fpsak-tidsserie</artifactId>
+                <version>${fpsak-tidsserie.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
@@ -124,6 +130,10 @@
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>dokarkiv-klient</artifactId>
             <version>${felles.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.fpsak.tidsserie</groupId>
+            <artifactId>fpsak-tidsserie</artifactId>
         </dependency>
 
         <!-- Google Cloud Storage - Buckets -->

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
@@ -7,18 +7,13 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.validation.ConstraintViolationException;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.soknad.innsending.fordel.BehandleEttersendelseTask;
 import no.nav.foreldrepenger.soknad.innsending.fordel.BehandleSøknadTask;
@@ -38,10 +33,6 @@ import no.nav.foreldrepenger.soknad.kontrakt.barn.BarnDto;
 import no.nav.foreldrepenger.soknad.kontrakt.barn.OmsorgsovertakelseDto;
 import no.nav.foreldrepenger.soknad.kontrakt.ettersendelse.EttersendelseDto;
 import no.nav.foreldrepenger.soknad.kontrakt.ettersendelse.YtelseType;
-import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.OppholdsPeriodeDto;
-import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.OverføringsPeriodeDto;
-import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.UttaksPeriodeDto;
-import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.UtsettelsesPeriodeDto;
 import no.nav.foreldrepenger.soknad.kontrakt.vedlegg.DokumentTypeId;
 import no.nav.foreldrepenger.soknad.kontrakt.vedlegg.InnsendingType;
 import no.nav.foreldrepenger.soknad.kontrakt.vedlegg.VedleggDto;
@@ -55,7 +46,6 @@ import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 @ApplicationScoped
 public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
-    private static final Logger LOG = LoggerFactory.getLogger(SøknadInnsendingTjeneste.class);
     private static final JsonMapper MAPPER = DefaultJsonMapper.getJsonMapper();
     private static final Environment ENV = Environment.current();
 
@@ -80,7 +70,8 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
 
     @Override
     public void lagreSøknadInnsending(SøknadDto søknad) {
-        validerUttaksperioder(søknad);
+        UttaksperioderValidator.valider(søknad);
+
         if (erForsendelseAlleredeMottatt(søknad)) {
             throw new DuplikatInnsendingException("Duplikat forsendelse av søknad mottatt for bruker, avbryter lagring og behandling");
         }
@@ -179,49 +170,6 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
         var task = ProsessTaskData.forProsessTask(BehandleEttersendelseTask.class);
         task.setProperty(FORSENDELSE_ID_PROPERTY, forsendelseId.toString());
         prosessTaskTjeneste.lagre(task);
-    }
-
-    private static void validerUttaksperioder(SøknadDto søknad) {
-        var uttaksperioder = switch (søknad) {
-            case ForeldrepengesøknadDto fp -> fp.uttaksplan().uttaksperioder();
-            case EndringssøknadForeldrepengerDto endring -> endring.uttaksplan().uttaksperioder();
-            default -> null;
-        };
-        if (uttaksperioder == null) {
-            return;
-        }
-
-        var søknadstype = søknad instanceof EndringssøknadForeldrepengerDto ? "endringssøknad" : "førstegangssøknad";
-        var saksnummer = søknad instanceof EndringssøknadForeldrepengerDto endring ? endring.saksnummer().value() : null;
-
-        if (uttaksperioder.isEmpty()) {
-            LOG.warn("Mottatt {} uten uttaksperioder{}", søknadstype, saksnummer != null ? ", saksnummer: " + saksnummer : "");
-            throw new ConstraintViolationException("Uttaksplan må inneholde minst én uttaksperiode", Set.of());
-        }
-
-        if (uttaksperioder.size() > 200) {
-            LOG.warn("Mottatt {} med {} uttaksperioder (maks 200){}", søknadstype, uttaksperioder.size(),
-                saksnummer != null ? ", saksnummer: " + saksnummer : "");
-            throw new ConstraintViolationException("Uttaksplan kan ikke inneholde mer enn 200 uttaksperioder", Set.of());
-        }
-
-        var ugyldigePerioder = uttaksperioder.stream()
-            .filter(p -> p.tom().isBefore(p.fom()))
-            .toList();
-
-        if (!ugyldigePerioder.isEmpty()) {
-            for (var periode : ugyldigePerioder) {
-                var periodetype = switch (periode) {
-                    case UttaksPeriodeDto _ -> "uttak";
-                    case OverføringsPeriodeDto _ -> "overføring";
-                    case OppholdsPeriodeDto _ -> "opphold";
-                    case UtsettelsesPeriodeDto _ -> "utsettelse";
-                };
-                LOG.warn("Mottatt {} med ugyldig uttaksperiode: type={}, fom={}, tom={}{}", søknadstype, periodetype, periode.fom(), periode.tom(),
-                    saksnummer != null ? ", saksnummer: " + saksnummer : "");
-            }
-            throw new ConstraintViolationException("Uttaksplan inneholder perioder der tom er før fom", Set.of());
-        }
     }
 
     private boolean erForsendelseAlleredeMottatt(UtalelseOmTilbakebetaling utalelseOmTilbakebetaling) {

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
@@ -23,6 +23,7 @@ import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentRepositor
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseEntitet;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseStatus;
 import no.nav.foreldrepenger.soknad.innsending.fordel.utils.SøknadJsonMapper;
+import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValidering;
 import no.nav.foreldrepenger.soknad.kontrakt.EndringssøknadForeldrepengerDto;
 import no.nav.foreldrepenger.soknad.kontrakt.EngangsstønadDto;
 import no.nav.foreldrepenger.soknad.kontrakt.ForeldrepengesøknadDto;
@@ -70,7 +71,7 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
 
     @Override
     public void lagreSøknadInnsending(SøknadDto søknad) {
-        UttaksperioderValidator.valider(søknad);
+        UttaksperioderValidering.valider(søknad);
 
         if (erForsendelseAlleredeMottatt(søknad)) {
             throw new DuplikatInnsendingException("Duplikat forsendelse av søknad mottatt for bruker, avbryter lagring og behandling");

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/UttaksperioderValidator.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/UttaksperioderValidator.java
@@ -1,0 +1,96 @@
+package no.nav.foreldrepenger.soknad.innsending;
+
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.validation.ConstraintViolationException;
+import no.nav.foreldrepenger.soknad.kontrakt.EndringssøknadForeldrepengerDto;
+import no.nav.foreldrepenger.soknad.kontrakt.ForeldrepengesøknadDto;
+import no.nav.foreldrepenger.soknad.kontrakt.SøknadDto;
+import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.OppholdsPeriodeDto;
+import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.OverføringsPeriodeDto;
+import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.UtsettelsesPeriodeDto;
+import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.UttaksPeriodeDto;
+import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.Uttaksplanperiode;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+
+public final class UttaksperioderValidator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UttaksperioderValidator.class);
+
+    private UttaksperioderValidator() {
+    }
+
+    public static void valider(SøknadDto søknad) {
+        var uttaksperioder = switch (søknad) {
+            case ForeldrepengesøknadDto fp -> fp.uttaksplan().uttaksperioder();
+            case EndringssøknadForeldrepengerDto endring -> endring.uttaksplan().uttaksperioder();
+            default -> null;
+        };
+
+        if (uttaksperioder == null) {
+            return;
+        }
+
+        var søknadBeskrivelse = søknad instanceof EndringssøknadForeldrepengerDto endring ?
+            "endringssøknad (saksnummer " + endring.saksnummer().value() + ")" : "førstegangssøknad";
+
+        requireMinstEnPeriode(uttaksperioder, søknadBeskrivelse);
+        requireAntallPerioderUnderTerskel(uttaksperioder, søknadBeskrivelse);
+        requireFomFørTom(uttaksperioder, søknadBeskrivelse);
+        requireIngenOverlapp(uttaksperioder, søknadBeskrivelse);
+    }
+
+    private static void requireMinstEnPeriode(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
+        if (uttaksperioder.isEmpty()) {
+            LOG.warn("Mottatt {} uten uttaksperioder", søknadBeskrivelse);
+            throw new ConstraintViolationException("Uttaksplan må inneholde minst én periode", Set.of());
+        }
+    }
+
+    private static void requireAntallPerioderUnderTerskel(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
+        if (uttaksperioder.size() > 200) {
+            LOG.warn("Mottatt {} med {} uttaksperioder (maks 200)", søknadBeskrivelse, uttaksperioder.size());
+            throw new ConstraintViolationException("Uttaksplan kan ikke inneholde mer enn 200 perioder", Set.of());
+        }
+    }
+
+    private static void requireFomFørTom(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
+        var perioderDerTomErFørFom = uttaksperioder.stream()
+            .filter(p -> p.tom().isBefore(p.fom()))
+            .map(UttaksperioderValidator::formatterPeriode)
+            .toList();
+
+        if (!perioderDerTomErFørFom.isEmpty()) {
+            LOG.warn("Mottatt {} med uttaksperiode(r) der tom er før fom: {}", søknadBeskrivelse, String.join(", ", perioderDerTomErFørFom));
+            throw new ConstraintViolationException("Uttaksplan inneholder perioder der tom er før fom", Set.of());
+        }
+    }
+
+    private static void requireIngenOverlapp(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
+        try {
+            var segmenter = uttaksperioder.stream().map(p -> new LocalDateSegment<>(p.fom(), p.tom(), formattertType(p))).toList();
+            new LocalDateTimeline<>(segmenter);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Mottatt {} der uttaksperioder overlapper: {}", søknadBeskrivelse, e.getMessage());
+            throw new ConstraintViolationException("Uttaksplan inneholder overlappende perioder", Set.of());
+        }
+    }
+
+    private static String formatterPeriode(Uttaksplanperiode periode) {
+        return String.format("{type=%s, fom=%s, tom=%s}", formattertType(periode), periode.fom(), periode.tom());
+    }
+
+    private static String formattertType(Uttaksplanperiode periode) {
+        return switch (periode) {
+            case UttaksPeriodeDto _ -> "uttak";
+            case OverføringsPeriodeDto _ -> "overføring";
+            case OppholdsPeriodeDto _ -> "opphold";
+            case UtsettelsesPeriodeDto _ -> "utsettelse";
+        };
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/validering/UttaksperioderValidering.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/validering/UttaksperioderValidering.java
@@ -1,12 +1,7 @@
-package no.nav.foreldrepenger.soknad.innsending;
+package no.nav.foreldrepenger.soknad.innsending.validering;
 
 import java.util.List;
-import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import jakarta.validation.ConstraintViolationException;
 import no.nav.foreldrepenger.soknad.kontrakt.EndringssøknadForeldrepengerDto;
 import no.nav.foreldrepenger.soknad.kontrakt.ForeldrepengesøknadDto;
 import no.nav.foreldrepenger.soknad.kontrakt.SøknadDto;
@@ -18,11 +13,11 @@ import no.nav.foreldrepenger.soknad.kontrakt.foreldrepenger.uttaksplan.Uttakspla
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 
-public final class UttaksperioderValidator {
+public final class UttaksperioderValidering {
 
-    private static final Logger LOG = LoggerFactory.getLogger(UttaksperioderValidator.class);
+    private static final int MAKS_ANTALL_PERIODER = 200;
 
-    private UttaksperioderValidator() {
+    private UttaksperioderValidering() {
     }
 
     public static void valider(SøknadDto søknad) {
@@ -47,45 +42,46 @@ public final class UttaksperioderValidator {
 
     private static void requireMinstEnPeriode(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
         if (uttaksperioder.isEmpty()) {
-            LOG.warn("Mottatt {} uten uttaksperioder", søknadBeskrivelse);
-            throw new ConstraintViolationException("Uttaksplan må inneholde minst én periode", Set.of());
+            var msg = String.format("Uttaksplan må inneholde minst én periode. Gjelder %s", søknadBeskrivelse);
+            throw new UttaksperioderValideringException(msg);
         }
     }
 
     private static void requireAntallPerioderUnderTerskel(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
-        if (uttaksperioder.size() > 200) {
-            LOG.warn("Mottatt {} med {} uttaksperioder (maks 200)", søknadBeskrivelse, uttaksperioder.size());
-            throw new ConstraintViolationException("Uttaksplan kan ikke inneholde mer enn 200 perioder", Set.of());
+        if (uttaksperioder.size() > MAKS_ANTALL_PERIODER) {
+            var msg = String.format("Uttaksplan kan ikke inneholde mer enn %s perioder. Gjelder %s med %s uttaksperioder", MAKS_ANTALL_PERIODER, søknadBeskrivelse, uttaksperioder.size());
+            throw new UttaksperioderValideringException(msg);
         }
     }
 
     private static void requireFomFørTom(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
         var perioderDerTomErFørFom = uttaksperioder.stream()
             .filter(p -> p.tom().isBefore(p.fom()))
-            .map(UttaksperioderValidator::formatterPeriode)
+            .map(UttaksperioderValidering::formatPeriode)
             .toList();
 
         if (!perioderDerTomErFørFom.isEmpty()) {
-            LOG.warn("Mottatt {} med uttaksperiode(r) der tom er før fom: {}", søknadBeskrivelse, String.join(", ", perioderDerTomErFørFom));
-            throw new ConstraintViolationException("Uttaksplan inneholder perioder der tom er før fom", Set.of());
+            var msg = String.format("Uttaksplan inneholder perioder der tom er før fom. Gjelder %s: %s", søknadBeskrivelse,
+                String.join(", ", perioderDerTomErFørFom));
+            throw new UttaksperioderValideringException(msg);
         }
     }
 
     private static void requireIngenOverlapp(List<Uttaksplanperiode> uttaksperioder, String søknadBeskrivelse) {
         try {
-            var segmenter = uttaksperioder.stream().map(p -> new LocalDateSegment<>(p.fom(), p.tom(), formattertType(p))).toList();
+            var segmenter = uttaksperioder.stream().map(p -> new LocalDateSegment<>(p.fom(), p.tom(), formatPeriodetype(p))).toList();
             new LocalDateTimeline<>(segmenter);
         } catch (IllegalArgumentException e) {
-            LOG.warn("Mottatt {} der uttaksperioder overlapper: {}", søknadBeskrivelse, e.getMessage());
-            throw new ConstraintViolationException("Uttaksplan inneholder overlappende perioder", Set.of());
+            var msg = String.format("Uttaksplan inneholder overlappende perioder. Gjelder %s: %s", søknadBeskrivelse, e.getMessage());
+            throw new UttaksperioderValideringException(msg);
         }
     }
 
-    private static String formatterPeriode(Uttaksplanperiode periode) {
-        return String.format("{type=%s, fom=%s, tom=%s}", formattertType(periode), periode.fom(), periode.tom());
+    private static String formatPeriode(Uttaksplanperiode periode) {
+        return String.format("{type=%s, fom=%s, tom=%s}", formatPeriodetype(periode), periode.fom(), periode.tom());
     }
 
-    private static String formattertType(Uttaksplanperiode periode) {
+    private static String formatPeriodetype(Uttaksplanperiode periode) {
         return switch (periode) {
             case UttaksPeriodeDto _ -> "uttak";
             case OverføringsPeriodeDto _ -> "overføring";

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/validering/UttaksperioderValideringException.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/validering/UttaksperioderValideringException.java
@@ -1,0 +1,18 @@
+package no.nav.foreldrepenger.soknad.innsending.validering;
+
+import no.nav.vedtak.exception.FunksjonellException;
+import no.nav.vedtak.feil.Feilkode;
+
+
+public class UttaksperioderValideringException extends FunksjonellException {
+
+    public UttaksperioderValideringException(String msg) {
+        super(null, msg);
+    }
+
+    @Override
+    public String getFeilkode() {
+        return Feilkode.VALIDERING.name();
+    }
+
+}

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -1,8 +1,10 @@
 package no.nav.foreldrepenger.soknad.innsending;
 
+import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.KontoType.FEDREKVOTE;
 import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.KontoType.FELLESPERIODE;
 import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.KontoType.FORELDREPENGER_FØR_FØDSEL;
 import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.KontoType.MØDREKVOTE;
+import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.Overføringsårsak.SYKDOM_ANNEN_FORELDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -417,6 +419,40 @@ class SøknadInnsendingTjenesteTest {
     }
 
     @Test
+    void foreldrepengesøknad_med_overlappende_uttaksperiode_skal_kaste_exception() {
+        // Arrange
+        var now = LocalDate.now();
+
+        var uttaksplan = List.of(
+            UttakplanPeriodeBuilder.uttak(MØDREKVOTE, now, now).build(),
+            UttakplanPeriodeBuilder.uttak(MØDREKVOTE, now, now.plusDays(3)).build()
+        );
+
+        var søknad = (ForeldrepengesøknadDto) new ForeldrepengerBuilder().medUttaksplan(uttaksplan).build();
+
+        // Act/Assert
+        assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessageContaining("Uttaksplan inneholder overlappende perioder");
+    }
+
+    @Test
+    void foreldrepengesøknad_med_overlapp_omsluttende_periode_skal_kaste_exception() {
+        // Arrange
+        var now = LocalDate.now();
+        var uttaksplan = List.of(
+            UttakplanPeriodeBuilder.uttak(MØDREKVOTE, now, now.plusDays(10)).build(),
+            UttakplanPeriodeBuilder.overføring(SYKDOM_ANNEN_FORELDER, FEDREKVOTE, now.plusDays(2), now.plusDays(2)).build()
+        );
+        var søknad = (ForeldrepengesøknadDto) new ForeldrepengerBuilder().medUttaksplan(uttaksplan).build();
+
+        // Act/Assert
+        assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessageContaining("Uttaksplan inneholder overlappende perioder");
+    }
+
+    @Test
     void endringssøknad_med_ugyldig_uttaksperiode_tom_før_fom_skal_kaste_exception() {
         // Arrange
         var fom = LocalDate.now();
@@ -455,7 +491,7 @@ class SøknadInnsendingTjenesteTest {
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
             .isInstanceOf(ConstraintViolationException.class)
-            .hasMessageContaining("minst én uttaksperiode");
+            .hasMessageContaining("minst én periode");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
     }
@@ -475,7 +511,7 @@ class SøknadInnsendingTjenesteTest {
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
             .isInstanceOf(ConstraintViolationException.class)
-            .hasMessageContaining("minst én uttaksperiode");
+            .hasMessageContaining("minst én periode");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
     }

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValideringException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.neovisionaries.i18n.CountryCode;
 
 import jakarta.persistence.EntityManager;
-import jakarta.validation.ConstraintViolationException;
 import no.nav.foreldrepenger.kontrakter.felles.typer.Fødselsnummer;
 import no.nav.foreldrepenger.kontrakter.felles.typer.Orgnummer;
 import no.nav.foreldrepenger.kontrakter.felles.typer.Saksnummer;
@@ -412,7 +413,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("tom er før fom");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
@@ -432,7 +433,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("Uttaksplan inneholder overlappende perioder");
     }
 
@@ -448,7 +449,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("Uttaksplan inneholder overlappende perioder");
     }
 
@@ -468,7 +469,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("tom er før fom");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
@@ -490,7 +491,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("minst én periode");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
@@ -510,7 +511,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Act/Assert
         assertThatThrownBy(() -> søknadInnsendingTjeneste.lagreSøknadInnsending(søknad))
-            .isInstanceOf(ConstraintViolationException.class)
+            .isInstanceOf(UttaksperioderValideringException.class)
             .hasMessageContaining("minst én periode");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();


### PR DESCRIPTION
Beholder eksplisitt validering. Bruker fpsak-tidsserie til sjekk, litt tynn bruk av biblioteket men gir superenkel validering.