### PR TITLE
TFP-4848: erstatt jobberFremdelesSomFrilans med tom i FrilansDto

### DIFF
--- a/kontrakter/src/main/java/no/nav/foreldrepenger/soknad/kontrakt/opptjening/FrilansDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/soknad/kontrakt/opptjening/FrilansDto.java
@@ -4,5 +4,5 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
 
-public record FrilansDto(boolean jobberFremdelesSomFrilans, @NotNull LocalDate oppstart) {
+public record FrilansDto(LocalDate tom, @NotNull LocalDate oppstart) {
 }

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/soknad/kontrakt/opptjening/FrilansDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/soknad/kontrakt/opptjening/FrilansDto.java
@@ -4,5 +4,5 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
 
-public record FrilansDto(LocalDate tom, @NotNull LocalDate oppstart) {
+public record FrilansDto(@NotNull LocalDate oppstart, LocalDate tom) {
 }

--- a/kontrakter/src/test/java/no/nav/foreldrepenger/soknad/kontrakt/builder/OpptjeningMaler.java
+++ b/kontrakter/src/test/java/no/nav/foreldrepenger/soknad/kontrakt/builder/OpptjeningMaler.java
@@ -15,7 +15,7 @@ public final class OpptjeningMaler {
     }
 
     public static FrilansDto frilansOpptjening() {
-        return new FrilansDto(null, LocalDate.now().minusYears(2));
+        return new FrilansDto(LocalDate.now().minusYears(2), null);
     }
 
     public static NæringDto egenNaeringOpptjening(String orgnummer) {

--- a/kontrakter/src/test/java/no/nav/foreldrepenger/soknad/kontrakt/builder/OpptjeningMaler.java
+++ b/kontrakter/src/test/java/no/nav/foreldrepenger/soknad/kontrakt/builder/OpptjeningMaler.java
@@ -15,7 +15,7 @@ public final class OpptjeningMaler {
     }
 
     public static FrilansDto frilansOpptjening() {
-        return new FrilansDto(false, LocalDate.now().minusYears(2));
+        return new FrilansDto(null, LocalDate.now().minusYears(2));
     }
 
     public static NæringDto egenNaeringOpptjening(String orgnummer) {


### PR DESCRIPTION
Fjerner ubrukt boolean jobberFremdelesSomFrilans fra kontrakten. Legger til nullable LocalDate tom for sluttdato som frilanser.

jobberFremdelesSomFrilans ble aldri brukt til noe