### PR TITLE
TFP-6997: sett gruppe og sekvens på innsendinger for logisk rekkefølge

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -83,7 +83,7 @@ spec:
     - name: GCP_BUCKET_NAME
       value: {{tmpbucket}}
   envFrom:
-    - secret: mellomlagring-kryptering # krypteringsnøkkel for mellomlagring
+    - secret: mellomlagring-kryptering # nøkler for mellomlagring og prosesstaskgruppe
   observability:
     autoInstrumentation:
       enabled: true

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
@@ -2,14 +2,10 @@ package no.nav.foreldrepenger.soknad.innsending;
 
 import static no.nav.foreldrepenger.soknad.innsending.fordel.BehandleSøknadTask.FORSENDELSE_ID_PROPERTY;
 
-import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.security.MessageDigest;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,6 +24,7 @@ import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentRepositor
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseEntitet;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseStatus;
 import no.nav.foreldrepenger.soknad.innsending.fordel.utils.SøknadJsonMapper;
+import no.nav.foreldrepenger.soknad.innsending.fordel.ProsessTaskGruppeUtleder;
 import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValidering;
 import no.nav.foreldrepenger.soknad.kontrakt.EndringssøknadForeldrepengerDto;
 import no.nav.foreldrepenger.soknad.kontrakt.EngangsstønadDto;
@@ -59,6 +56,7 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
     private InnloggetBruker innloggetBruker;
     private DokumentRepository dokumentRepository;
     private ProsessTaskTjeneste prosessTaskTjeneste;
+    private ProsessTaskGruppeUtleder prosessTaskGruppeUtleder;
 
     public SøknadInnsendingTjeneste() {
         //CDI
@@ -67,11 +65,13 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
     public SøknadInnsendingTjeneste(MellomlagringTjeneste mellomlagringTjeneste,
                                     InnloggetBruker innloggetBruker,
                                     DokumentRepository dokumentRepository,
-                                    ProsessTaskTjeneste prosessTaskTjeneste) {
+                                    ProsessTaskTjeneste prosessTaskTjeneste,
+                                    ProsessTaskGruppeUtleder prosessTaskGruppeUtleder) {
         this.mellomlagringTjeneste = mellomlagringTjeneste;
         this.innloggetBruker = innloggetBruker;
         this.dokumentRepository = dokumentRepository;
         this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.prosessTaskGruppeUtleder = prosessTaskGruppeUtleder;
     }
 
     @Override
@@ -107,7 +107,7 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             .toList();
         vedleggDokumenter.forEach(dokumentRepository::lagre);
 
-        var gruppe = pseudonymisertBrukerId(innloggetBruker.brukerFraKontekst());
+        var gruppe = prosessTaskGruppeUtleder.prosesstaskGruppeFor(innloggetBruker.brukerFraKontekst());
         var task = ProsessTaskData.forProsessTask(BehandleSøknadTask.class);
         task.setProperty(FORSENDELSE_ID_PROPERTY, forsendelseId.toString());
         task.setGruppe(gruppe);
@@ -147,7 +147,7 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             .toList();
         vedleggDokumenter.forEach(dokumentRepository::lagre);
 
-        var gruppe = pseudonymisertBrukerId(innloggetBruker.brukerFraKontekst());
+        var gruppe = prosessTaskGruppeUtleder.prosesstaskGruppeFor(innloggetBruker.brukerFraKontekst());
         var task = ProsessTaskData.forProsessTask(BehandleEttersendelseTask.class);
         task.setProperty(FORSENDELSE_ID_PROPERTY, forsendelseId.toString());
         task.setGruppe(gruppe);
@@ -316,18 +316,6 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             return new VedleggSkjemanummerWrapper(innhold, vedleggDto.skjemanummer(), Optional.of(begrunnelse));
         }
         return new VedleggSkjemanummerWrapper(innhold, vedleggDto.skjemanummer(), Optional.empty());
-    }
-
-    private static String pseudonymisertBrukerId(String brukerIdent) {
-        try {
-            var digest = MessageDigest.getInstance("SHA-256");
-            digest.update("fp-soknad".getBytes(StandardCharsets.UTF_8));
-            var hash = digest.digest(brukerIdent.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash).substring(0, 16);
-
-        } catch (GeneralSecurityException e) {
-            throw new IllegalStateException("SHA-256 ikke tilgjengelig", e); // er tilgjengelig i JVM
-        }
     }
 
     private record VedleggSkjemanummerWrapper(byte[] innhold, DokumentTypeId skjemanummer, Optional<String> begrunnelse) {}

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
@@ -2,12 +2,19 @@ package no.nav.foreldrepenger.soknad.innsending;
 
 import static no.nav.foreldrepenger.soknad.innsending.fordel.BehandleSøknadTask.FORSENDELSE_ID_PROPERTY;
 
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -102,8 +109,11 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             .toList();
         vedleggDokumenter.forEach(dokumentRepository::lagre);
 
+        var gruppe = pseudonymisertBrukerId(innloggetBruker.brukerFraKontekst());
         var task = ProsessTaskData.forProsessTask(BehandleSøknadTask.class);
         task.setProperty(FORSENDELSE_ID_PROPERTY, forsendelseId.toString());
+        task.setGruppe(gruppe);
+        task.setSekvens(String.valueOf(Instant.now().toEpochMilli()));
         prosessTaskTjeneste.lagre(task);
     }
 
@@ -139,8 +149,11 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             .toList();
         vedleggDokumenter.forEach(dokumentRepository::lagre);
 
+        var gruppe = pseudonymisertBrukerId(innloggetBruker.brukerFraKontekst());
         var task = ProsessTaskData.forProsessTask(BehandleEttersendelseTask.class);
         task.setProperty(FORSENDELSE_ID_PROPERTY, forsendelseId.toString());
+        task.setGruppe(gruppe);
+        task.setSekvens(String.valueOf(Instant.now().toEpochMilli()));
         prosessTaskTjeneste.lagre(task);
     }
 
@@ -305,6 +318,18 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
             return new VedleggSkjemanummerWrapper(innhold, vedleggDto.skjemanummer(), Optional.of(begrunnelse));
         }
         return new VedleggSkjemanummerWrapper(innhold, vedleggDto.skjemanummer(), Optional.empty());
+    }
+
+    private static String pseudonymisertBrukerId(String brukerIdent) {
+        var åpentSalt = "fp-soknad";
+        try {
+            var mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(åpentSalt.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            var hash = mac.doFinal(brukerIdent.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, 16);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA256 ikke tilgjengelig", e); // er tilgjengelig i JVM
+        }
     }
 
     private record VedleggSkjemanummerWrapper(byte[] innhold, DokumentTypeId skjemanummer, Optional<String> begrunnelse) {}

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjeneste.java
@@ -4,6 +4,7 @@ import static no.nav.foreldrepenger.soknad.innsending.fordel.BehandleSøknadTask
 
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -12,9 +13,6 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -321,14 +319,14 @@ public class SøknadInnsendingTjeneste implements InnsendingTjeneste {
     }
 
     private static String pseudonymisertBrukerId(String brukerIdent) {
-        var åpentSalt = "fp-soknad";
         try {
-            var mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(åpentSalt.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            var hash = mac.doFinal(brukerIdent.getBytes(StandardCharsets.UTF_8));
+            var digest = MessageDigest.getInstance("SHA-256");
+            digest.update("fp-soknad".getBytes(StandardCharsets.UTF_8));
+            var hash = digest.digest(brukerIdent.getBytes(StandardCharsets.UTF_8));
             return HexFormat.of().formatHex(hash).substring(0, 16);
+
         } catch (GeneralSecurityException e) {
-            throw new IllegalStateException("HmacSHA256 ikke tilgjengelig", e); // er tilgjengelig i JVM
+            throw new IllegalStateException("SHA-256 ikke tilgjengelig", e); // er tilgjengelig i JVM
         }
     }
 

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/fordel/ProsessTaskGruppeUtleder.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/fordel/ProsessTaskGruppeUtleder.java
@@ -1,0 +1,49 @@
+package no.nav.foreldrepenger.soknad.innsending.fordel;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Objects;
+
+@ApplicationScoped
+public class ProsessTaskGruppeUtleder {
+
+    private static final String HMAC_ALGORITME = "HmacSHA256";
+
+    private byte[] hmacKey;
+
+
+    public ProsessTaskGruppeUtleder() {
+        // CDI
+    }
+
+    @Inject
+    public ProsessTaskGruppeUtleder(@KonfigVerdi(value = "PT_UID_HMAC_KEY") String hmacKeyBase64) {
+        Objects.requireNonNull(hmacKeyBase64, "PT_UID_HMAC_KEY mangler");
+        this.hmacKey = Base64.getDecoder().decode(hmacKeyBase64);
+    }
+
+    public String prosesstaskGruppeFor(String brukerIdent) {
+        Objects.requireNonNull(brukerIdent, "brukerIdent mangler");
+        return hmacHex(brukerIdent).substring(0, 16);
+    }
+
+    private String hmacHex(String brukerIdent) {
+        try {
+            var mac = Mac.getInstance(HMAC_ALGORITME);
+            mac.init(new SecretKeySpec(hmacKey, HMAC_ALGORITME));
+            var tagBytes = mac.doFinal(brukerIdent.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(tagBytes);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA256 ikke tilgjengelig", e); // er tilgjengelig i JVM
+        }
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/soknad/innsending/fordel/ProsessTaskGruppeUtleder.java
+++ b/src/main/java/no/nav/foreldrepenger/soknad/innsending/fordel/ProsessTaskGruppeUtleder.java
@@ -26,8 +26,8 @@ public class ProsessTaskGruppeUtleder {
     }
 
     @Inject
-    public ProsessTaskGruppeUtleder(@KonfigVerdi(value = "PT_UID_HMAC_KEY") String hmacKeyBase64) {
-        Objects.requireNonNull(hmacKeyBase64, "PT_UID_HMAC_KEY mangler");
+    public ProsessTaskGruppeUtleder(@KonfigVerdi(value = "PT_GRUPPE_HMAC_SECRET") String hmacKeyBase64) {
+        Objects.requireNonNull(hmacKeyBase64, "PT_GRUPPE_HMAC_SECRET mangler");
         this.hmacKey = Base64.getDecoder().decode(hmacKeyBase64);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -13,11 +13,11 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.jose4j.base64url.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -84,7 +84,7 @@ class SøknadInnsendingTjenesteTest {
     @BeforeEach
     void setUp(EntityManager entityManager) {
         dokumentRepository = new DokumentRepository(entityManager);
-        var ptGruppeUtleder = new ProsessTaskGruppeUtleder(Base64.encode("HMAC_SECRET".getBytes()));
+        var ptGruppeUtleder = new ProsessTaskGruppeUtleder(Base64.getEncoder().encodeToString("HMAC_SECRET".getBytes()));
         søknadInnsendingTjeneste = new SøknadInnsendingTjeneste(mellomlagringTjeneste, innloggetBruker, dokumentRepository, prosessTaskTjeneste,
             ptGruppeUtleder);
     }

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -84,7 +84,7 @@ class SøknadInnsendingTjenesteTest {
     @BeforeEach
     void setUp(EntityManager entityManager) {
         dokumentRepository = new DokumentRepository(entityManager);
-        var ptGruppeUtleder = new ProsessTaskGruppeUtleder(Base64.encode("HMAC_KEY".getBytes()));
+        var ptGruppeUtleder = new ProsessTaskGruppeUtleder(Base64.encode("HMAC_SECRET".getBytes()));
         søknadInnsendingTjeneste = new SøknadInnsendingTjeneste(mellomlagringTjeneste, innloggetBruker, dokumentRepository, prosessTaskTjeneste,
             ptGruppeUtleder);
     }
@@ -538,7 +538,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Assert
         verify(prosessTaskTjeneste).lagre(taskDataCaptor.capture());
-        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("e2c236c373d1b649");
+        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("bf05ae03af3662b1");
         assertThat(taskDataCaptor.getValue().getSekvens()).isNotBlank().isNotEqualTo("1");
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -8,6 +8,7 @@ import static no.nav.foreldrepenger.kontrakter.felles.kodeverk.Overføringsårsa
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -16,11 +17,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValideringException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -36,6 +36,7 @@ import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentEntitet;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentRepository;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseStatus;
 import no.nav.foreldrepenger.soknad.innsending.fordel.utils.SøknadJsonMapper;
+import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValideringException;
 import no.nav.foreldrepenger.soknad.kontrakt.BrukerRolle;
 import no.nav.foreldrepenger.soknad.kontrakt.ForeldrepengesøknadDto;
 import no.nav.foreldrepenger.soknad.kontrakt.SøkerDto;
@@ -61,6 +62,7 @@ import no.nav.foreldrepenger.soknad.kontrakt.vedlegg.InnsendingType;
 import no.nav.foreldrepenger.soknad.kontrakt.vedlegg.VedleggDto;
 import no.nav.foreldrepenger.soknad.mellomlagring.MellomlagringTjeneste;
 import no.nav.foreldrepenger.soknad.utils.InnloggetBruker;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ExtendWith(MockitoExtension.class)
@@ -362,8 +364,6 @@ class SøknadInnsendingTjenesteTest {
         assertThat(uttalelseDokument.getArkivFilType()).isEqualTo(ArkivFilType.JSON);
         var deseralisertUttalelse = SøknadJsonMapper.deseraliserUttalelsePåTilbakebetaling(uttalelseDokument);
         assertThat(deseralisertUttalelse).isEqualTo(new UtalelseOmTilbakebetaling(ettersendelse.type(), ettersendelse.brukerTekst()));
-
-
     }
 
     @Test
@@ -515,5 +515,26 @@ class SøknadInnsendingTjenesteTest {
             .hasMessageContaining("minst én periode");
 
         assertThat(dokumentRepository.hentForsendelse(fnr.value())).isEmpty();
+    }
+
+    @Test
+    void innsending_skal_sette_gruppe_og_sekvens() {
+        // Arrange
+        var fnr = new Fødselsnummer("1234567890");
+        var søknad = new EngangsstønadBuilder()
+            .medSøkerinfo(new SøkerDto(fnr, new SøkerDto.Navn("Per", null, "Pål"), null))
+            .medBarn(new FødselDto(2, LocalDate.now().minusMonths(1), LocalDate.now().minusMonths(1).plusWeeks(2)))
+            .medUtenlandsopphold(List.of(new UtenlandsoppholdsperiodeDto(LocalDate.now().minusYears(1), LocalDate.now().minusMonths(6), CountryCode.XK)))
+            .build();
+        when(innloggetBruker.brukerFraKontekst()).thenReturn(fnr.value());
+        var taskDataCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
+
+        // Act
+        søknadInnsendingTjeneste.lagreSøknadInnsending(søknad);
+
+        // Assert
+        verify(prosessTaskTjeneste).lagre(taskDataCaptor.capture());
+        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("563cbaf0043a2ad6");
+        assertThat(taskDataCaptor.getValue().getSekvens()).isNotBlank().isNotEqualTo("1");
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -534,7 +534,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Assert
         verify(prosessTaskTjeneste).lagre(taskDataCaptor.capture());
-        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("563cbaf0043a2ad6");
+        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("187bbdfd764bba51");
         assertThat(taskDataCaptor.getValue().getSekvens()).isNotBlank().isNotEqualTo("1");
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/soknad/innsending/SøknadInnsendingTjenesteTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.jose4j.base64url.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,7 @@ import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentEntitet;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.DokumentRepository;
 import no.nav.foreldrepenger.soknad.innsending.fordel.dokument.ForsendelseStatus;
 import no.nav.foreldrepenger.soknad.innsending.fordel.utils.SøknadJsonMapper;
+import no.nav.foreldrepenger.soknad.innsending.fordel.ProsessTaskGruppeUtleder;
 import no.nav.foreldrepenger.soknad.innsending.validering.UttaksperioderValideringException;
 import no.nav.foreldrepenger.soknad.kontrakt.BrukerRolle;
 import no.nav.foreldrepenger.soknad.kontrakt.ForeldrepengesøknadDto;
@@ -82,7 +84,9 @@ class SøknadInnsendingTjenesteTest {
     @BeforeEach
     void setUp(EntityManager entityManager) {
         dokumentRepository = new DokumentRepository(entityManager);
-        søknadInnsendingTjeneste = new SøknadInnsendingTjeneste(mellomlagringTjeneste, innloggetBruker, dokumentRepository, prosessTaskTjeneste);
+        var ptGruppeUtleder = new ProsessTaskGruppeUtleder(Base64.encode("HMAC_KEY".getBytes()));
+        søknadInnsendingTjeneste = new SøknadInnsendingTjeneste(mellomlagringTjeneste, innloggetBruker, dokumentRepository, prosessTaskTjeneste,
+            ptGruppeUtleder);
     }
 
     @Test
@@ -534,7 +538,7 @@ class SøknadInnsendingTjenesteTest {
 
         // Assert
         verify(prosessTaskTjeneste).lagre(taskDataCaptor.capture());
-        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("187bbdfd764bba51");
+        assertThat(taskDataCaptor.getValue().getGruppe()).isEqualTo("e2c236c373d1b649");
         assertThat(taskDataCaptor.getValue().getSekvens()).isNotBlank().isNotEqualTo("1");
     }
 }

--- a/src/test/resources/application-vtp.properties
+++ b/src/test/resources/application-vtp.properties
@@ -36,8 +36,9 @@ truststore.relativ.path=/.modig/truststore.jks
 
 DB_JDBC_URL=jdbc:postgresql://localhost:5999/fpsoknad?password=fpsoknad&user=fpsoknad
 
-# Mellomlagring
-KRYPTERING_PASSWORD=testnokkelforvtp
+# mellomlagring og prosesstaskgruppe secret
+KRYPTERING_PASSWORD=LqLt3JtCDXs6msZP5QhygZXdAP1n8CBNF884ZWNUIU64hCRZqmA9soK7zpk=
+PT_GRUPPE_HMAC_SECRET=Fgl48QEOyC/feE//1ECu/8F97rbhLDEFx/vyqSOCIs0=
 
 # Integrasjoner
 dokarkiv.base.url=https://localhost:8063/rest/dokarkiv/rest/journalpostapi/v1/journalpost


### PR DESCRIPTION
Forslag til enkel løsning. Bruker første 16 tegn som gruppe. Se test case for eksempel.

Merge etter https://github.com/navikt/fp-autotest/pull/1940